### PR TITLE
SIF3Infra: fix environment_xml column type being a too small VARCHAR(…

### DIFF
--- a/SIF3InfraREST/sif3Common/src/sif3/common/persist/model/SIF3Infra.hbm.xml
+++ b/SIF3InfraREST/sif3Common/src/sif3/common/persist/model/SIF3Infra.hbm.xml
@@ -23,7 +23,7 @@
         <property name="securityToken" column="SECURITY_TOKEN" type="string" length="200"/>
         <property name="securityTokenExpiry" column="SECURITY_TOKEN_EXPIRY" type="timestamp"/>
         <property name="adapterType" column="ADAPTER_TYPE" type="string" length="20"/>
-        <property name="environmentXML" column="ENVIRONMENT_XML" type="string"/>
+        <property name="environmentXML" column="ENVIRONMENT_XML" type="text"/>
         <property name="queueStrategy" column="QUEUE_STRATEGY" type="string"/>
         <property name="created" column="CREATED" type="timestamp"/>
         <property name="lastAccessed" column="LAST_ACCESSED" type="timestamp"/>


### PR DESCRIPTION
SIF3Infra: fix environment_xml column type being a too small VARCHAR(255)

The default type for string seems to be a VARCHAR(255) which seems to be too small for modern environments. This changes it to text (which maps to text in postgresql) to make it more environmentally friendly when auto-creating the SIF3 infrastructure schema in hibernate.

Issue #8